### PR TITLE
Messages page frontend events

### DIFF
--- a/Frontend/src/components/HomePageComponents/TripSimpleInputComponent/TripSimpleInputComponent.js
+++ b/Frontend/src/components/HomePageComponents/TripSimpleInputComponent/TripSimpleInputComponent.js
@@ -1,5 +1,5 @@
 import { EventHub } from "../../../lib/eventhub/eventHub.js";
-import { Events } from "../../../lib/eventhub/Events.js";
+import { Events } from "../../../lib/eventhub/events.js";
 import { BaseComponent } from "../../BaseComponent/BaseComponent.js";
 
 export class TripSimpleInputComponent extends BaseComponent {

--- a/Frontend/src/components/MessagePageComponents/ChatDisplayComponent/ChatDisplayComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatDisplayComponent/ChatDisplayComponent.js
@@ -57,7 +57,21 @@ export class ChatDisplayComponent extends BaseComponent {
 
     #attachEventListeners() {
         const hub = EventHub.getInstance();
-        hub.subscribe(Events.OpenChat, chatData => this.#displayChat(chatData));
+        // hub.subscribe(Events.OpenChat, chatData => this.#displayChat(chatData));
+
+        const input_box = this.#container.querySelector("#input-box");
+        input_box.addEventListener("keypress", (event) => {
+            if (event.key === "Enter" && event.target.value !== ""){
+                const newMessage = document.createElement("div");
+                newMessage.classList.add("chat-bubble");
+                newMessage.classList.add("chat-to");
+                newMessage.textContent = event.target.value + " [Zavier]";
+            
+                const display = document.getElementById("messages-display");
+                display.appendChild(newMessage);
+                input_box.value = "";
+            }
+});
 
         // TODO
         // sending new message

--- a/Frontend/src/components/MessagePageComponents/ChatDisplayComponent/ChatDisplayComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatDisplayComponent/ChatDisplayComponent.js
@@ -4,6 +4,7 @@ import { Events } from "../../../lib/eventhub/events.js";
 
 export class ChatDisplayComponent extends BaseComponent {
     #container = null;
+    #hub = EventHub.getInstance();
 
     constructor() {
         super();
@@ -56,8 +57,10 @@ export class ChatDisplayComponent extends BaseComponent {
     }
 
     #attachEventListeners() {
-        const hub = EventHub.getInstance();
-        // hub.subscribe(Events.OpenChat, chatData => this.#displayChat(chatData));
+        this.#hub.subscribe(Events.OpenChatSuccess, (chatData) => this.#displayChat(chatData));
+        this.#hub.subscribe(Events.OpenChatFailure, () => {
+            alert("Error: couldn't display chat.");
+        });
 
         const input_box = this.#container.querySelector("#input-box");
         input_box.addEventListener("keypress", (event) => {
@@ -71,9 +74,9 @@ export class ChatDisplayComponent extends BaseComponent {
                 display.appendChild(newMessage);
                 input_box.value = "";
             }
-});
+        });
 
-        // TODO
+        // TODO:
         // sending new message
         // retrieving new message
     }

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.css
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.css
@@ -35,3 +35,9 @@
     position: absolute;
     background-color: white;
 }
+
+#loading-message {
+    position: absolute;
+    top: 100px;
+    left: 50px
+}

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -167,9 +167,9 @@ export class ChatListComponent extends BaseComponent {
 
     #handleChatCreationStart() {
         // Grab info from popup form
-        const profileID = document.forms["form-container"].profile_id.value;
-        const chatName = document.forms["form-container"].chat_name.value;
-        const tripName = document.forms["form-container"].trip_id.value;
+        const profileID = this.#container.querySelector('.form-container').profile_id.value;
+        const chatName = this.#container.querySelector('.form-container').chat_name.value;
+        const tripName = this.#container.querySelector('.form-container').trip_id.value;
 
         if (!(profileID && chatName)) {
             alert("Please enter a Profile ID and Chat name if you would like to create a chat.");

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -42,12 +42,12 @@ export class ChatListComponent extends BaseComponent {
 
     #setupContainerContent() {
         this.#container.innerHTML = `
-        <h1>Chats<input id="add-chat-button" type="button" value="+"></h1>
+        <h1>Chats<input id="add-chat-button" type="button" value="+" style="display: none;"></h1>
         `;
         
         // comment out next 2 lines if not using mock data:
-        this.#container.innerHTML += `<input class="chat-icon" type="button" value="👤 Jasper">
-        <input class="chat-icon" type="button" value="👤 Joon">`;     
+        // this.#container.innerHTML += `<input class="chat-icon" type="button" value="👤 Jasper">
+        // <input class="chat-icon" type="button" value="👤 Joon">`;     
 
         const createChatPopupForm = document.createElement("form");
         createChatPopupForm.classList.add("form-container");
@@ -81,6 +81,7 @@ export class ChatListComponent extends BaseComponent {
         this.#hub.subscribe(Events.RetrieveUserDataSuccess, (userData) => {
             this.#setUserData(userData);
             this.#loadExistingChats();
+            this.#container.querySelector('#add-chat-button').style.display = "block";
         });
         this.#hub.subscribe(Events.RetrieveUserDataFailure, () => {
             alert("Error: couldn't retrieve user data from the server. Please refresh the page or contact an admin.");

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -43,6 +43,7 @@ export class ChatListComponent extends BaseComponent {
     #setupContainerContent() {
         this.#container.innerHTML = `
         <h1>Chats<input id="add-chat-button" type="button" value="+" style="display: none;"></h1>
+        <span id="loading-message">Loading Chat and user data...</span>
         `;
         
         // comment out next 2 lines if not using mock data:
@@ -82,6 +83,8 @@ export class ChatListComponent extends BaseComponent {
             this.#setUserData(userData);
             this.#loadExistingChats();
             this.#container.querySelector('#add-chat-button').style.display = "block";
+            this.#container.querySelector('#loading-message').style.display = "none";
+
         });
         this.#hub.subscribe(Events.RetrieveUserDataFailure, () => {
             alert("Error: couldn't retrieve user data from the server. Please refresh the page or contact an admin.");

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -73,7 +73,6 @@ export class ChatListComponent extends BaseComponent {
         // Grab user data & display associated tabs
         const TEMP_USER_ID = 1
         this.#retreiveUserData(TEMP_USER_ID);
-        this.#loadExistingChats();
     }
 
     #attachEventListeners() {
@@ -81,6 +80,7 @@ export class ChatListComponent extends BaseComponent {
         // Retrieving user's data for particular userID
         this.#hub.subscribe(Events.RetrieveUserDataSuccess, (userData) => {
             this.#setUserData(userData);
+            this.#loadExistingChats();
         });
         this.#hub.subscribe(Events.RetrieveUserDataFailure, () => {
             alert("Error: couldn't retrieve user data from the server. Please refresh the page or contact an admin.");

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -103,7 +103,6 @@ export class ChatListComponent extends BaseComponent {
         // Storing new Chat ID to user
         this.#hub.subscribe(Events.AddChatIDToUserPermissionsSuccess, (id) => {
             this.#addChatIDToUserPermissions(id);
-
         });
         this.#hub.subscribe(Events.AddChatIDToUserPermissionsFailure, () => {
             alert("Error: unable to add chat ID to the user's permissions on server.");

--- a/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
+++ b/Frontend/src/components/MessagePageComponents/ChatListComponent/ChatListComponent.js
@@ -34,7 +34,6 @@ export class ChatListComponent extends BaseComponent {
         this.#createContainer();
         this.#setupContainerContent();
         this.#attachEventListeners();
-        console.log(this.#container.outerHTML);
         return this.#container;
     }
 

--- a/Frontend/src/lib/eventhub/eventHub.js
+++ b/Frontend/src/lib/eventhub/eventHub.js
@@ -16,6 +16,7 @@ export class EventHub {
 
     // Publish an event
     publish(event, data) {
+        console.log(`Publishing event: ${event}`);
         if (!this.events[event]) return;
         this.events[event].forEach((listener) => listener(data));
     }

--- a/Frontend/src/lib/eventhub/events.js
+++ b/Frontend/src/lib/eventhub/events.js
@@ -34,11 +34,11 @@ export const Events = {
     StoreNewChatGroupSuccess: 'StoreNewChatGroupSuccess',
     StoreNewChatGroupFailure: 'StoreNewChatGroupFailure',
 
-    // this is unimplemented in messages page
+    // ======= this is unimplemented in messages page
     AcceptChatInvitation: 'AcceptChatInvitation',
     AcceptChatInvitationSuccess: 'AcceptChatInvitationSuccess',
     AcceptChatInvitationFailure: 'AcceptChatInvitationFailure',
-    //
+    // ========
 
     RequestUserData: 'RequestUserData',
     RequestUserDataSuccess: 'RequestUserDataSuccess',

--- a/Frontend/src/lib/eventhub/events.js
+++ b/Frontend/src/lib/eventhub/events.js
@@ -34,13 +34,23 @@ export const Events = {
     StoreNewChatGroupSuccess: 'StoreNewChatGroupSuccess',
     StoreNewChatGroupFailure: 'StoreNewChatGroupFailure',
 
+    // this is unimplemented in messages page
     AcceptChatInvitation: 'AcceptChatInvitation',
     AcceptChatInvitationSuccess: 'AcceptChatInvitationSuccess',
     AcceptChatInvitationFailure: 'AcceptChatInvitationFailure',
+    //
+
+    RequestUserData: 'RequestUserData',
+    RequestUserDataSuccess: 'RequestUserDataSuccess',
+    RequestUserDataFailure: 'RequestUserDataFailure',
 
     RetrieveUserData: 'RetrieveUserData',
     RetrieveUserDataSuccess: 'RetrieveUserDataSuccess',
     RetrieveUserDataFailure: 'RetrieveUserDataFailure',
+
+    RequestChatData: 'RequestChatData',
+    RequestChatDataSuccess: 'RequestChatDataSuccess',
+    RequestChatDataFailure: 'RequestChatDataFailure',
 
     RetrieveChatData: 'RetrieveChatData',
     RetrieveChatDataSuccess: 'RetrieveChatDataSuccess',

--- a/Frontend/src/main.js
+++ b/Frontend/src/main.js
@@ -1,5 +1,5 @@
 import { ScreenControllerComponent } from "./components/ScreenControllerComponent/ScreenControllerComponent.js";
-// import { TripRepositoryFactory } from "./services/TripRepositoryFactory.js";
+import { TripRepositoryFactory } from "./services/TripRepositoryFactory.js";
 
 // Create instance
 const screenController = new ScreenControllerComponent();
@@ -9,4 +9,4 @@ const screenContainer = document.getElementById("app");
 screenContainer.appendChild(screenController.render());
 
 // Services
-// const tripRepository = TripRepositoryFactory.get("fake");
+const tripRepository = TripRepositoryFactory.get("remote");

--- a/Frontend/src/services/Service.js
+++ b/Frontend/src/services/Service.js
@@ -1,4 +1,4 @@
-import { EventHub } from '/lib/eventhub/EventHub.js';
+import { EventHub } from '../lib/eventhub/eventHub.js';
 
 /**
  * @abstract

--- a/Frontend/src/services/TripRepositoryFactory.js
+++ b/Frontend/src/services/TripRepositoryFactory.js
@@ -1,6 +1,6 @@
-import { TripRepositoryService } from "./TripRepositoryService";
-import { TripRepositoryRemoteFakeService } from "./TripRepositoryFakeService";
-import { TripRepositoryRemoteService } from "./TripRepositoryRemoteService";
+import { TripRepositoryService } from "./TripRepositoryService.js";
+import { TripRepositoryRemoteFakeService } from "./TripRepositoryFakeService.js";
+import { TripRepositoryRemoteService } from "./TripRepositoryRemoteService.js";
 
 export class TripRepositoryFactory {
     constructor() {

--- a/Frontend/src/services/TripRepositoryRemoteService.js
+++ b/Frontend/src/services/TripRepositoryRemoteService.js
@@ -18,6 +18,9 @@ export class TripRepositoryRemoteService extends Service {
         });
     }
 
+    /**
+     * Trip services:
+     */
     async #initTrips() {
         const response = await fetch("/trips");
 
@@ -62,7 +65,16 @@ export class TripRepositoryRemoteService extends Service {
     }
 
     async #toBase64(tripData) {
-        throw new Error("Not yet implemented");
+        if (tripData.file) {
+            // Need to store the mime type separately as it is needed when
+            // converting back to blob when fetched from the server.
+            tripData.mime = tripData.file.type;
+            // Store the filename separately as well
+            tripData.filename = tripData.file.name;
+            // Convert the file to base64
+            const base64 = await Base64.convertFileToBase64(tripData.file);
+            tripData.file = base64;
+          }
     }
 
     async clearTrips() {

--- a/Frontend/src/services/TripRepositoryRemoteService.js
+++ b/Frontend/src/services/TripRepositoryRemoteService.js
@@ -16,7 +16,7 @@ export class TripRepositoryRemoteService extends Service {
             this.storeTrip(data);
         });
 
-        this.subscribe(Events.UnstoreTrips, () => {
+        this.subscribe(Events.UnStoreTrips, () => {
             this.clearTrips();
         });
         /**
@@ -31,7 +31,7 @@ export class TripRepositoryRemoteService extends Service {
             this.retrieveChats(chat_ids);
         });
         this.subscribe(Events.RequestUserData, (id) => {
-            this.retrieveUser(id);
+            this.retrieveUser(id.id);
         });
         this.subscribe(Events.StoreNewChatGroup, (chatData) => {
             this.storeChatGroup(chatData);
@@ -47,7 +47,7 @@ export class TripRepositoryRemoteService extends Service {
     async #initTrips() {
         const response = await fetch("/trips");
         if (!response.ok) {
-            throw new Error("Failed to fetch tasks");
+            throw new Error("Failed to fetch trips");
         }
         const data = await response.json();
 
@@ -77,7 +77,7 @@ export class TripRepositoryRemoteService extends Service {
         });
 
         if (!response.ok) {
-            throw new Error("Failed to store task");
+            throw new Error("Failed to store trip");
         }
 
         const data = await response.json();
@@ -91,7 +91,7 @@ export class TripRepositoryRemoteService extends Service {
         const data = await response.json();
 
         if (!response.ok) {
-            throw new Error("Failed to clear tasks");
+            throw new Error("Failed to clear trips");
         }
 
         // Notify subscribers that trips are cleared from the server

--- a/Frontend/src/services/TripRepositoryRemoteService.js
+++ b/Frontend/src/services/TripRepositoryRemoteService.js
@@ -1,10 +1,13 @@
 import Service from "./Service.js";
-import { Events } from "../eventhub/Events.js";
+import { Events } from "../lib/eventhub/events.js";
 import Base64 from "../utility/base64.js";
 
 export class TripRepositoryRemoteService extends Service {
     constructor() {
         super();
+        const TEMP_USER_ID = 1; // TODO: pass this into constructor from main.
+        // this.#initUser(TEMP_USER_ID);
+        // this.#initChats(TEMP_USER_ID);
         this.#initTrips();
     }
 
@@ -16,6 +19,26 @@ export class TripRepositoryRemoteService extends Service {
         this.subscribe(Events.UnstoreTrips, () => {
             this.clearTrips();
         });
+        /**
+         * TODO:
+         * - RequestChatData
+         * - RequestUserData
+         * - StoreNewChatGroup
+         * - AddChatIdToUserPermissions
+         * 
+         */
+        this.subscribe(Events.RequestChatData, (chat_ids) => {
+            this.retrieveChats(chat_ids);
+        });
+        this.subscribe(Events.RequestUserData, (id) => {
+            this.retrieveUser(id);
+        });
+        this.subscribe(Events.StoreNewChatGroup, (chatData) => {
+            this.storeChatGroup(chatData);
+        })
+        this.subscribe(Events.AddChatIDToUserPermissions, (user_and_chat_IDs) => {
+            this.storeIDGroupWithUser(user_and_chat_IDs);
+        })
     }
 
     /**
@@ -23,11 +46,9 @@ export class TripRepositoryRemoteService extends Service {
      */
     async #initTrips() {
         const response = await fetch("/trips");
-
         if (!response.ok) {
             throw new Error("Failed to fetch tasks");
         }
-
         const data = await response.json();
 
         data.tasks.forEach(async (trip) => {
@@ -39,7 +60,6 @@ export class TripRepositoryRemoteService extends Service {
                     trip.filename
                 );
             }
-
             // Publish the task.
             this.publish(Events.NewTrip, trip);
         });
@@ -64,19 +84,6 @@ export class TripRepositoryRemoteService extends Service {
         return data;
     }
 
-    async #toBase64(tripData) {
-        if (tripData.file) {
-            // Need to store the mime type separately as it is needed when
-            // converting back to blob when fetched from the server.
-            tripData.mime = tripData.file.type;
-            // Store the filename separately as well
-            tripData.filename = tripData.file.name;
-            // Convert the file to base64
-            const base64 = await Base64.convertFileToBase64(tripData.file);
-            tripData.file = base64;
-          }
-    }
-
     async clearTrips() {
         const response = await fetch("/trips", {
             method: "DELETE",
@@ -92,4 +99,131 @@ export class TripRepositoryRemoteService extends Service {
 
         return data;
     }
+
+    /**
+     * Chat services:
+     */
+    async #initChats(id) {
+        const response = await fetch(`/chats:id${id}`);
+        if (!response.ok) {
+            this.publish(Events.RetrieveChatDataFailure);
+        }
+        const data = await response.json();
+
+        if (data.chatData.file) {
+            chatData.file = Base64.convertBase64ToFile(
+                chatData.file,
+                chatData.mime,
+                chatData.filename
+            );
+        }
+
+        this.publish(Events.RetrieveChatDataSuccess, chatData);
+    }
+
+    async retrieveChats(chats_ids) {
+        const response = await fetch(`/chats/${chats_ids}`);
+        if (!response.ok) {
+            this.publish(Events.RetrieveChatDataFailure);
+        }
+        const data = await response.json();
+
+        if (data.chatData.file) {
+            chatData.file = Base64.convertBase64ToFile(
+                chatData.file,
+                chatData.mime,
+                chatData.filename
+            );
+        }
+
+        this.publish(Events.RetrieveChatDataSuccess, chatData);
+    }
+
+    async storeChatGroup(chatData) {
+        await this.#toBase64(chatData);
+
+        const response = await fetch("/chats", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(chatData),
+        });
+
+        if (!response.ok) {
+            this.publish(Events.StoreNewChatGroupFailure);
+        }
+
+        const data = await response.json();
+        this.publish(Events.StoreNewChatGroupSuccess, data);
+    }
+
+    async #initUser(id) { // where will this be implemented?
+        const response = await fetch(`/user/${id}`);
+        if (!response.ok) {
+            this.publish(Events.RequestUserDataFailure);
+        }
+        const data = await response.json();
+
+        if (data.userData.file) {
+            userData.file = Base64.convertBase64ToFile(
+                userData.file,
+                userData.mime,
+                userData.filename
+            );
+        }
+
+        this.publish(Events.RequestUserDataSuccess, userData);
+    }
+
+    async retrieveUser(id) {
+        const response = await fetch(`/user/${id}`);
+        if (!response.ok) {
+            this.publish(Events.RequestUserDataFailure);
+        }
+        const data = await response.json();
+
+        if (data.userData.file) {
+            userData.file = Base64.convertBase64ToFile(
+                userData.file,
+                userData.mime,
+                userData.filename
+            );
+        }
+
+        this.publish(Events.RequestUserDataSuccess, userData);
+    }
+
+    async storeIDGroupWithUser(user_and_chat_IDs) {
+        await this.#toBase64(user_and_chat_IDs);
+
+        const response = await fetch(`/user/${user_and_chat_IDs.user_id}`, {
+            method: "UPDATE",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({chat_id: user_and_chat_IDs.id}),
+        });
+
+        if (!response.ok) {
+            this.publish(Events.StoreNewChatGroupFailure);
+        }
+
+        const data = await response.json();
+        this.publish(Events.StoreNewChatGroupSuccess, data);
+    }
+
+    async #toBase64(tripData) {
+        if (tripData.file) {
+            // Need to store the mime type separately as it is needed when
+            // converting back to blob when fetched from the server.
+            tripData.mime = tripData.file.type;
+            // Store the filename separately as well
+            tripData.filename = tripData.file.name;
+            // Convert the file to base64
+            const base64 = await Base64.convertFileToBase64(tripData.file);
+            tripData.file = base64;
+          }
+    }
 }
+

--- a/Frontend/src/services/TripRepositoryService.js
+++ b/Frontend/src/services/TripRepositoryService.js
@@ -1,4 +1,4 @@
-import { Events } from '/lib/eventhub/Events.js';
+import { Events } from '../lib/eventhub/events.js';
 import Service from './Service.js';
 
 export class TripRepositoryService extends Service {


### PR DESCRIPTION
Implemented the following and connected with RemoteService via eventhub:
 - RequestUserData (page initialization)
 - RequestChatData (page initialization)
 - StoreNewChat (chat group creation)
 - AddChatToUserPermissions (chat group creation)

Messages page now doesn't show option to add new chats until user's data is fetched, which prevents users from attempting to create a chat when data doesn't exist yet to associate that new chat with a user. Once user data is fetched, then corresponding chats are loaded (upon a chatData fetch).

Also fixed TripRepositoryRemoteService.js, so it is run from main.js and makes corresponding fetches when page loads.